### PR TITLE
fix: prevent overwriting rollout state with synthetic variables

### DIFF
--- a/synther/online/online_exp.py
+++ b/synther/online/online_exp.py
@@ -244,8 +244,8 @@ def redq_sac(
             observations, actions, rewards, next_observations, terminals = generator.sample(num_samples=num_samples)
 
             print(f'Adding {num_samples} samples to replay buffer.')
-            for o, a, r, o2, term in zip(observations, actions, rewards, next_observations, terminals):
-                agent.diffusion_buffer.store(o, a, r, o2, term)
+            for o_s, a_s, r_s, o2_s, term_s in zip(observations, actions, rewards, next_observations, terminals):
+                agent.diffusion_buffer.store(o_s, a_s, r_s, o2_s, term_s)
 
             if print_buffer_stats:
                 ptr_location = agent.replay_buffer.ptr


### PR DESCRIPTION
### Description
This PR resolves a variable name collision in `online_exp.py` that inadvertently overwrites the real rollout states during synthetic transition insertion. 

### Changes Made
* Renamed the local variables in the synthetic insertion loop from `o, a, r, o2, term` to `o_s, a_s, r_s, o2_s, term_s`.
* This ensures the live rollout loop correctly utilizes the true environment observations for computing the next action, preventing potential divergence after diffusion retraining.

### Related Issue
Fixes #9 