### PR TITLE
[codex] Improve code health and device portability

### DIFF
--- a/synther/corl/algorithms/cql.py
+++ b/synther/corl/algorithms/cql.py
@@ -820,7 +820,7 @@ def train(config: TrainConfig):
 
     if config.load_model != "":
         policy_file = Path(config.load_model)
-        trainer.load_state_dict(torch.load(policy_file))
+        trainer.load_state_dict(torch.load(policy_file, map_location=config.device))
         actor = trainer.actor
 
     # wandb_init(asdict(config))

--- a/synther/corl/algorithms/iql.py
+++ b/synther/corl/algorithms/iql.py
@@ -499,7 +499,7 @@ def train(config: TrainConfig):
 
     if config.load_model != "":
         policy_file = Path(config.load_model)
-        trainer.load_state_dict(torch.load(policy_file))
+        trainer.load_state_dict(torch.load(policy_file, map_location=config.device))
         actor = trainer.actor
 
     # wandb_init(asdict(config))

--- a/synther/corl/algorithms/td3_bc.py
+++ b/synther/corl/algorithms/td3_bc.py
@@ -390,7 +390,7 @@ def train(config: TrainConfig):
 
     if config.load_model != "":
         policy_file = Path(config.load_model)
-        trainer.load_state_dict(torch.load(policy_file))
+        trainer.load_state_dict(torch.load(policy_file, map_location=config.device))
         actor = trainer.actor
 
     # wandb_init(asdict(config))

--- a/synther/corl/shared/buffer.py
+++ b/synther/corl/shared/buffer.py
@@ -207,7 +207,7 @@ class DiffusionGenerator(ReplayBufferBase):
         inputs = torch.from_numpy(inputs).float()
         self.diffusion = construct_diffusion_model(inputs=inputs).to(device)
 
-        data = torch.load(diffusion_path)
+        data = torch.load(diffusion_path, map_location=device)
         if use_ema:
             ema_dict = data['ema']
             ema_dict = {k: v for k, v in ema_dict.items() if k.startswith('ema_model')}

--- a/synther/diffusion/elucidated_diffusion.py
+++ b/synther/diffusion/elucidated_diffusion.py
@@ -284,13 +284,15 @@ class Trainer(object):
             amp: bool = False,
             fp16: bool = False,
             split_batches: bool = True,
+            use_gpu: bool = True,
     ):
         super().__init__()
         self.accelerator = Accelerator(
             split_batches=split_batches,
-            mixed_precision='fp16' if fp16 else 'no'
+            mixed_precision='fp16' if fp16 and use_gpu else 'no',
+            cpu=not use_gpu,
         )
-        self.accelerator.native_amp = amp
+        self.accelerator.native_amp = amp and use_gpu
         self.model = diffusion_model
 
         num_params = sum(p.numel() for p in self.model.parameters() if p.requires_grad)
@@ -308,7 +310,13 @@ class Trainer(object):
                 self.batch_size = train_batch_size
             print(f'Using batch size: {self.batch_size}')
             # dataset and dataloader
-            dl = DataLoader(dataset, batch_size=self.batch_size, shuffle=True, pin_memory=True, num_workers=cpu_count())
+            dl = DataLoader(
+                dataset,
+                batch_size=self.batch_size,
+                shuffle=True,
+                pin_memory=use_gpu,
+                num_workers=cpu_count(),
+            )
             dl = self.accelerator.prepare(dl)
             self.dl = cycle(dl)
         else:

--- a/synther/diffusion/norm.py
+++ b/synther/diffusion/norm.py
@@ -1,6 +1,6 @@
 # Normalizers for diffusion.
 
-from typing import List
+from typing import List, Optional
 
 import torch
 from torch import nn
@@ -43,16 +43,16 @@ class Normalizer(BaseNormalizer):
             self,
             dataset: torch.Tensor,
             eps: float = 1e-5,
-            skip_dims: List[int] = [],
+            skip_dims: Optional[List[int]] = None,
             target_std: float = 1.0,
     ):
         super().__init__()
         self.register_buffer('mean', dataset.mean(dim=0))
         self.register_buffer('std', dataset.std(dim=0) + eps)
-        self.skip_dims = skip_dims
-        if skip_dims:
-            self.mean[skip_dims] = 0.0
-            self.std[skip_dims] = 1.0
+        self.skip_dims = [] if skip_dims is None else list(skip_dims)
+        if self.skip_dims:
+            self.mean[self.skip_dims] = 0.0
+            self.std[self.skip_dims] = 1.0
         self.target_std = target_std
         print('Means:', self.mean)
         print('Stds:', self.std)
@@ -76,7 +76,7 @@ class Normalizer(BaseNormalizer):
 def normalizer_factory(
         normalizer_type: str,
         dataset: torch.Tensor,
-        skip_dims: List[int] = [],
+        skip_dims: Optional[List[int]] = None,
         **kwargs,
 ) -> BaseNormalizer:
     if normalizer_type == 'minmax':

--- a/synther/diffusion/train_diffuser.py
+++ b/synther/diffusion/train_diffuser.py
@@ -2,7 +2,7 @@
 import argparse
 import pathlib
 
-import d4rl
+import d4rl  # noqa: F401
 import gin
 import gym
 import numpy as np
@@ -36,7 +36,8 @@ class SimpleDiffusionGenerator:
             self,
             num_samples: int,
     ) -> (np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray):
-        assert num_samples % self.sample_batch_size == 0, 'num_samples must be a multiple of sample_batch_size'
+        if num_samples % self.sample_batch_size != 0:
+            raise ValueError('num_samples must be a multiple of sample_batch_size')
         num_batches = num_samples // self.sample_batch_size
         observations = []
         actions = []
@@ -84,12 +85,15 @@ if __name__ == '__main__':
     parser.add_argument('--wandb-group', type=str, default="diffusion_training")
     #
     parser.add_argument('--results_folder', type=str, default='./results')
-    parser.add_argument('--use_gpu', action='store_true', default=True)
+    parser.add_argument('--use_gpu', '--use-gpu', dest='use_gpu', action='store_true')
+    parser.add_argument('--no_use_gpu', '--no-use-gpu', dest='use_gpu', action='store_false')
     parser.add_argument('--seed', type=int, default=0)
-    parser.add_argument('--save_samples', action='store_true', default=True)
+    parser.add_argument('--save_samples', '--save-samples', dest='save_samples', action='store_true')
+    parser.add_argument('--no_save_samples', '--no-save-samples', dest='save_samples', action='store_false')
     parser.add_argument('--save_num_samples', type=int, default=int(5e6))
     parser.add_argument('--save_file_name', type=str, default='5m_samples.npz')
     parser.add_argument('--load_checkpoint', action='store_true')
+    parser.set_defaults(use_gpu=True, save_samples=True)
     args = parser.parse_args()
 
     gin.parse_config_files_and_bindings(args.gin_config_files, args.gin_params)
@@ -117,6 +121,7 @@ if __name__ == '__main__':
         diffusion,
         dataset,
         results_folder=args.results_folder,
+        use_gpu=args.use_gpu,
     )
 
     if not args.load_checkpoint:
@@ -126,7 +131,7 @@ if __name__ == '__main__':
             entity=args.wandb_entity,
             config=args,
             group=args.wandb_group,
-            name=args.results_folder.split('/')[-1],
+            name=results_folder.name,
         )
         # Train model.
         trainer.train()

--- a/synther/diffusion/utils.py
+++ b/synther/diffusion/utils.py
@@ -9,7 +9,7 @@ import torch
 from torch import nn
 
 # GIN-required Imports.
-from synther.diffusion.denoiser_network import ResidualMLPDenoiser
+from synther.diffusion.denoiser_network import ResidualMLPDenoiser  # noqa: F401
 from synther.diffusion.elucidated_diffusion import ElucidatedDiffusion
 from synther.diffusion.norm import normalizer_factory
 
@@ -66,9 +66,10 @@ def construct_diffusion_model(
         normalizer_type: str,
         denoising_network: nn.Module,
         disable_terminal_norm: bool = False,
-        skip_dims: List[int] = [],
+        skip_dims: Optional[List[int]] = None,
         cond_dim: Optional[int] = None,
 ) -> ElucidatedDiffusion:
+    skip_dims = [] if skip_dims is None else list(skip_dims)
     event_dim = inputs.shape[1]
     model = denoising_network(d_in=event_dim, cond_dim=cond_dim)
 

--- a/synther/online/online_exp.py
+++ b/synther/online/online_exp.py
@@ -3,7 +3,7 @@
 import sys
 import time
 
-import dmcgym
+import dmcgym  # noqa: F401
 import gin
 import gym
 import numpy as np
@@ -29,7 +29,7 @@ def redq_sac(
         steps_per_epoch=1000,
         max_ep_len=1000,
         n_evals_per_epoch=1,
-        logger_kwargs=dict(),
+        logger_kwargs=None,
         debug=False,
         # following are agent related hyperparameters
         hidden_sizes=(256, 256),
@@ -108,12 +108,17 @@ def redq_sac(
         epochs = mbpo_epoches.get(env_name, 300)
     total_steps = steps_per_epoch * epochs + 1
 
+    if logger_kwargs is None:
+        logger_kwargs = {}
+
     """set up logger"""
     logger = EpochLogger(**logger_kwargs)
     logger.save_config(locals())
 
     """set up environment and seeding"""
-    env_fn = lambda: wrap_gym(gym.make(env_name))
+    def env_fn():
+        return wrap_gym(gym.make(env_name))
+
     env, test_env, bias_eval_env = env_fn(), env_fn(), env_fn()
     # seed torch and numpy
     torch.manual_seed(seed)
@@ -173,7 +178,7 @@ def redq_sac(
         'q_target_mode': q_target_mode,
         'policy_update_delay': policy_update_delay,
     }
-    wandb.init(project=project_name, name=logger_kwargs['exp_name'])
+    wandb.init(project=project_name, name=logger_kwargs.get('exp_name', env_name))
     wandb.config.update(agent_config)
     agent = REDQRLPDAgent(diffusion_buffer_size, diffusion_sample_ratio, env_name, obs_dim, act_dim, act_limit, device,
                           hidden_sizes, replay_size, batch_size,


### PR DESCRIPTION
## Summary
This PR tightens several low-risk code-health paths across the training utilities and RL entrypoints.

It:
- fixes mutable default arguments in diffusion model and normalizer configuration
- makes checkpoint loading device-portable by using `map_location`
- wires `--no-use-gpu` through to the diffusion trainer so CPU execution is actually honored
- replaces brittle runtime assertions and CLI boolean handling with clearer behavior
- cleans up a couple of logger and run-name defaults in the online training entrypoint

## Why
A few small utility paths were easy to trip over in practice:
- mutable defaults could leak state between calls
- model loading could fail when checkpoint device and runtime device differed
- the new CPU flag in `train_diffuser.py` needed to affect `Accelerator` device selection to avoid unexpected CUDA usage

## Impact
These changes improve portability and reduce hidden footguns without changing the core training algorithms.

Users should now get more predictable behavior when:
- loading checkpoints on CPU-only machines
- forcing diffusion training onto CPU
- constructing diffusion models repeatedly with different normalization settings

## Validation
- `python -m compileall synther`
- `ruff check synther`
- `pytest` (collects 0 tests in this repository)
